### PR TITLE
Reduce opendj-init storage classes to one and use one PVC

### DIFF
--- a/charts/ldap/templates/opendj-init-statefulset.yml
+++ b/charts/ldap/templates/opendj-init-statefulset.yml
@@ -24,21 +24,9 @@ spec:
       #           - {{ template "gluu.fullname" . }}-service
       #       topologyKey: "kubernetes.io/hostname"
       volumes:
-        - name: {{ template "gluu.fullname" . }}-config
+        - name: opendj-init-volume
           persistentVolumeClaim:
             claimName: {{ template "gluu.fullname" . }}-config-pvc
-        - name: {{ template "gluu.fullname" . }}-ldif
-          persistentVolumeClaim:
-            claimName: {{ template "gluu.fullname" . }}-ldif-pvc
-        - name: {{ template "gluu.fullname" . }}-logs
-          persistentVolumeClaim:
-            claimName: {{ template "gluu.fullname" . }}-logs-pvc
-        - name: {{ template "gluu.fullname" . }}-db
-          persistentVolumeClaim:
-            claimName: {{ template "gluu.fullname" . }}-db-pvc
-        - name: {{ template "gluu.fullname" . }}-flag
-          persistentVolumeClaim:
-            claimName: {{ template "gluu.fullname" . }}-flag-pvc
       containers:
       - name: {{ template "gluu.fullname" . }}-init-container
         imagePullPolicy: {{ .Values.imagePullPolicy }}
@@ -56,16 +44,11 @@ spec:
           - containerPort: 4444
             name: admin
         volumeMounts:
-          - mountPath: /opt/opendj/config
-            name: {{ template "gluu.fullname" . }}-config
-          - mountPath: /opt/opendj/ldif
-            name: {{ template "gluu.fullname" . }}-ldif
-          - mountPath: /opt/opendj/logs
-            name: {{ template "gluu.fullname" . }}-logs
-          - mountPath: /opt/opendj/db
-            name: {{ template "gluu.fullname" . }}-db
-          - mountPath: /flag
-            name: {{ template "gluu.fullname" . }}-flag
+        {{- with $key, $value := .Values.volumeInitMounts }}
+          - mountPath: {{ $value.mountPath }}
+            name: {{ $value.name }}
+            subPath: {{ $key }}
+        {{- end }}
         readinessProbe:
           tcpSocket: 
             port: {{ .Values.tcpSocket.port }}

--- a/charts/ldap/templates/opendj-init-statefulset.yml
+++ b/charts/ldap/templates/opendj-init-statefulset.yml
@@ -35,16 +35,12 @@ spec:
         - configMapRef:
             name: {{ template "gluu.fullname" . }}-init-cm
         ports:
-          - containerPort: 1636
-            name: ldaps
-          - containerPort: 1389
-            name: ldap
-          - containerPort: 8989
-            name: replication
-          - containerPort: 4444
-            name: admin
+        {{- range $key, $value := .Values.ports }}
+          - containerPort: {{ $value.targetPort }}
+            name: {{ $key }}
+        {{- end }}
         volumeMounts:
-        {{- with $key, $value := .Values.volumeInitMounts }}
+        {{- range $key, $value := .Values.volumeInitMounts }}
           - mountPath: {{ $value.mountPath }}
             name: {{ $value.name }}
             subPath: {{ $key }}

--- a/charts/ldap/templates/opendj-pvc.yml
+++ b/charts/ldap/templates/opendj-pvc.yml
@@ -3,13 +3,9 @@ apiVersion: v1
 metadata:
   name: {{ template "gluu.fullname" . }}-config-pvc
 spec:
-  storageClassName: {{ template "gluu.fullname" . }}-config-init-sc
+  storageClassName: {{ template "gluu.fullname" . }}-opendj-init-sc
   accessModes:
     - ReadWriteOnce
   resources:
     requests:
       storage: {{ .Values.storage }}
-  selector:
-    matchLabels:
-      opendj: {{ template "gluu.fullname" . }}-config
-

--- a/charts/ldap/templates/opendj-pvc.yml
+++ b/charts/ldap/templates/opendj-pvc.yml
@@ -3,7 +3,7 @@ apiVersion: v1
 metadata:
   name: {{ template "gluu.fullname" . }}-config-pvc
 spec:
-  storageClassName: {{ template "gluu.fullname" . }}-config-sc
+  storageClassName: {{ template "gluu.fullname" . }}-config-init-sc
   accessModes:
     - ReadWriteOnce
   resources:
@@ -13,71 +13,3 @@ spec:
     matchLabels:
       opendj: {{ template "gluu.fullname" . }}-config
 
----
-
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-  name: {{ template "gluu.fullname" . }}-ldif-pvc
-spec:
-  storageClassName: {{ template "gluu.fullname" . }}-ldif-sc
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: {{ .Values.storage }}
-  selector:
-    matchLabels:
-      opendj: {{ template "gluu.fullname" . }}-ldif
-
----
-
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-  name: {{ template "gluu.fullname" . }}-logs-pvc
-spec:
-  storageClassName: {{ template "gluu.fullname" . }}-logs-sc
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: {{ .Values.storage }}
-  selector:
-    matchLabels:
-      opendj: {{ template "gluu.fullname" . }}-logs
-
----
-
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-  name: {{ template "gluu.fullname" . }}-db-pvc
-spec:
-  storageClassName: {{ template "gluu.fullname" . }}-db-sc
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: {{ .Values.storage }}
-  selector:
-    matchLabels:
-      opendj: {{ template "gluu.fullname" . }}-db
-
----
-
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-  name: {{ template "gluu.fullname" . }}-flag-pvc
-spec:
-  storageClassName: {{ template "gluu.fullname" . }}-flag-sc
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: {{ .Values.storage }}
-  selector:
-    matchLabels:
-      opendj: {{ template "gluu.fullname" . }}-flag
-      

--- a/charts/ldap/values.yaml
+++ b/charts/ldap/values.yaml
@@ -52,37 +52,37 @@ ports:
 volumeInitMounts:
   config:
     mountPath: /opt/opendj/config
-    name: opendj-init-ss-volume
+    name: opendj-init-volume
   ldif: 
     mountPath: /opt/opendj/ldif
-    name: opendj-init-ss-volume
+    name: opendj-init-volume
   logs: 
     mountPath: /opt/opendj/logs
-    name: opendj-init-ss-volume
+    name: opendj-init-volume
   db: 
     mountPath: /opt/opendj/db
-    name: opendj-init-ss-volume
+    name: opendj-init-volume
   flag: 
     mountPath: /flag
-    name: opendj-init-ss-volume
+    name: opendj-init-volume
 
 #opedj-repl vm
 volumeReplMounts:
   config:
     mountPath: /opt/opendj/config
-    name: opendj-repl-ss-volume
+    name: opendj-repl-volume
   ldif: 
     mountPath: /opt/opendj/ldif
-    name: opendj-repl-ss-volume
+    name: opendj-repl-volume
   logs: 
     mountPath: /opt/opendj/logs
-    name: opendj-repl-ss-volume
+    name: opendj-repl-volume
   db: 
     mountPath: /opt/opendj/db
-    name: opendj-repl-ss-volume
+    name: opendj-repl-volume
   flag: 
     mountPath: /flag
-    name: opendj-repl-ss-volume
+    name: opendj-repl-volume
 
 #VolumeClaimTemplates
 storage: 1Gi


### PR DESCRIPTION
### What does this PR do?
- Reduces the number of storage classes used for dynamic provisioning. 

### Description of work done
- Reduce `StorageClasses` to one
- Reduce `PVC` to one
- Use `subPath` to store files in different directories